### PR TITLE
Add push and scope member when formatting requests

### DIFF
--- a/fortimanager/module_utils/network/fortimanager/common.py
+++ b/fortimanager/module_utils/network/fortimanager/common.py
@@ -161,6 +161,10 @@ class FMGRCommon(object):
             else:
                 if kwargs.get("data", False):
                     params[0]["data"] = kwargs["data"]
+                    if kwargs.get("scope member", False):
+                        params[0]["scope member"] = kwargs["scope member"]
+                    if kwargs.get("push", False):
+                        params[0]["push"] = kwargs["push"]
                 else:
                     params[0]["data"] = kwargs
         return params


### PR DESCRIPTION
Add push and scope member when formatting requests for FortiManager, which are used by wireless-controller and switch-controller API endpoints, outside of the usual data dict.